### PR TITLE
Setup Astro GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy Astro site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main  # build on every push to main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate deployment of the Astro site to GitHub Pages. The workflow is triggered on every push to the `main` branch and handles building the project and deploying it using official GitHub Actions.

Deployment automation:

* Added `.github/workflows/deploy.yml` to define a workflow for building and deploying the Astro site to GitHub Pages on every push to `main`.
* Configured two jobs: `build` (checks out code, sets up Node, installs dependencies, builds the site, and uploads the build artifact) and `deploy` (deploys the uploaded artifact to GitHub Pages).
* Set up permissions and concurrency to ensure secure and efficient deployment.